### PR TITLE
Adds a wp-cli command that repairs incomplete stateless metadata

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,11 +5,11 @@
 // add_action( 'wp_head', 'gpnz_enqueue_script', 11 );
 // function gpnz_enqueue_script() {
 // 	global $post;
-	
+
 // 	wp_enqueue_script( 'phone-format-js', get_stylesheet_directory_uri().'/phoneFormat.js', false );
 // 	wp_enqueue_script( 'jquery-inputmask-js', get_stylesheet_directory_uri().'/jquery.inputmask.bundle.min.js', false );
-	
-	
+
+
 // }
 
 add_action( 'wp_enqueue_scripts', 'enqueue_child_styles', 99);
@@ -22,7 +22,7 @@ function enqueue_child_styles() {
 }
 
 add_action( 'gform_post_payment_completed', function ( $entry, $action ) {
-     
+
     // Do something here.
  	echo "gform_post_payment_completed entry<br/>";
 	echo "<pre>";
@@ -38,26 +38,26 @@ add_action( 'gform_post_payment_completed', function ( $entry, $action ) {
 	// get details
 
 	// add details
- 
+
 }, 10, 2 );
 
 
 
 
 add_filter( 'gform_stripe_customer_id', function ( $customer_id, $feed, $entry, $form ) {
- 
+
     $feed_name = rgars( $feed, 'meta/feedName' );
- 
+
     gf_stripe()->log_debug( 'gform_stripe_customer_id: Running for Feed: ' . $feed_name );
- 
+
     // Define the names of the feeds you want this code to run.
     $feed_names = array( 'Donation' );
- 
+
     // Abort if the entry was processed by a different feed or it's not a product and services feed.
     if ( rgars( $feed, 'meta/transactionType' ) !== 'product' && ! in_array( $feed_name, $feed_names ) ) {
         return $customer_id;
     }
- 
+
     if ( empty( $customer_id ) ) {
         $response = gf_stripe()->get_stripe_js_response();
         if ( ! empty( $response->id ) && substr( $response->id, 0, 3 ) === 'pi_' ) {
@@ -65,36 +65,36 @@ add_filter( 'gform_stripe_customer_id', function ( $customer_id, $feed, $entry, 
                 $intent = \Stripe\PaymentIntent::retrieve( $response->id );
                 if ( ! empty( $intent->customer ) ) {
                     gf_stripe()->log_debug( 'gform_stripe_customer_id: PaymentIntent already has customer; ' . print_r( $intent->customer, true ) );
- 
+
                     return is_object( $intent->customer ) ? $intent->customer->id : $intent->customer;
                 }
             } catch ( \Exception $e ) {
                 gf_stripe()->log_debug( 'gform_stripe_customer_id: unable to get PaymentIntent; ' . $e->getMessage() );
             }
         }
- 
+
         $customer_params = array();
- 
+
         // $email_field = rgars( $feed, 'meta/receipt_field' );
         // if ( ! empty( $email_field ) && strtolower( $email_field ) !== 'do not send receipt' ) {
         //     $customer_params['email'] = gf_stripe()->get_field_value( $form, $entry, $email_field );
         // }
- 
+
         // // Optional - Customer name using a Name field that has id 8. Update the id number or remove the following line.
         // $customer_params['name'] = rgar( $entry, '8.3' ) . ' ' . rgar( $entry, '8.6' );
         // gf_stripe()->log_debug( __METHOD__ . '(): Name: ' . $customer_params['name'] );
- 
+
         // // Optional - Customer phone using a Phone field that has id 5. Update the id number or remove the following line.
         // $customer_params['phone'] = rgar( $entry, '5' );
         // gf_stripe()->log_debug( __METHOD__ . '(): Phone: ' . $customer_params['phone'] );
- 
+
         $customer    = gf_stripe()->create_customer( $customer_params, $feed, $entry, $form );
         $customer_id = $customer->id;
         gf_stripe()->log_debug( 'gform_stripe_customer_id: Returning Customer ID: ' . $customer_id );
     }
- 
+
     return $customer_id;
- 
+
 }, 10, 4 );
 
 
@@ -160,3 +160,5 @@ add_filter( 'gform_stripe_customer_id', function ( $customer_id, $feed, $entry, 
 
 // add_action('woocommerce_payment_complete', 'add_card_details');
 
+// wp-cli commands
+require_once 'wp-cli.php';

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -1,0 +1,122 @@
+<?php
+
+if (!defined('WP_CLI') || !WP_CLI) {
+    return;
+}
+
+class WP_Mediafiles_Repair_Command {
+
+    /**
+     * Repairs incomplete WP-Stateless (sm_cloud) metadata.
+     *
+     * ## OPTIONS
+     *
+     * [--dry-run]
+     * : Only show what would be changed; do not update the database.
+     *
+     * ## EXAMPLES
+     *
+     *     wp mediafiles repair
+     *     wp mediafiles repair --dry-run
+     */
+    public function repair($args, $assoc_args) {
+        $dry_run = isset($assoc_args['dry-run']);
+
+        $stateless = function_exists('ud_get_stateless_media') ? ud_get_stateless_media() : null;
+        if (!$stateless) {
+            WP_CLI::error('WP-Stateless plugin not detected or not active.');
+        }
+
+        $bucket = $stateless->get('sm.bucket');
+        WP_CLI::log('Using bucket: ' . $bucket);
+        $baseurl = untrailingslashit($stateless->get_gs_host());
+        WP_CLI::log('Using base URL: ' . $baseurl);
+
+        $fixed = 0;
+        $not_needed = 0;
+        $paged = 1;
+        $per_page = 30;
+
+        do {
+            $query = new WP_Query([
+                'post_type' => 'attachment',
+                'posts_per_page' => $per_page,
+                'paged' => $paged,
+                'post_status' => 'any',
+                'fields' => 'ids',
+            ]);
+
+            if (!$query->have_posts()) {
+                break;
+            }
+
+            foreach ($query->posts as $id) {
+                $sm_cloud = get_post_meta( $id, 'sm_cloud', true );
+
+                $file_path = get_post_meta($id, '_wp_attached_file', true);
+
+                if (empty($file_path)) {
+                    WP_CLI::log('Attachment #' .$id . ' has no _wp_attached_file meta. Skipping.');
+                    continue;
+                }
+
+                $needs_fix =
+                    empty($sm_cloud) ||
+                    empty($sm_cloud['name']) ||
+                    empty($sm_cloud['bucket']) ||
+                    empty($sm_cloud['fileLink']);
+
+                if (!$needs_fix) {
+                    WP_CLI::log('Attachment #' .$id . ' is already complete. Skipping.');
+                    $not_needed++;
+                    continue;
+                }
+
+                $file_path = ltrim($file_path, '/');
+
+                // Check if it already includes year/month structure
+                if (!preg_match('#^\d{4}/\d{2}/#', $file_path)) {
+                    // No year/month structure → reconstruct from attachment post_date.
+                    $post = get_post($id);
+                    if ($post && !empty($post->post_date)) {
+                        $year = date('Y', strtotime($post->post_date));
+                        $month = date('m', strtotime($post->post_date));
+                        $file_path = "$year/$month/$file_path";
+                    }
+                }
+
+                $filelink = trailingslashit($baseurl) . $file_path;
+
+                if (empty($sm_cloud)) {
+                    $sm_cloud = [];
+                }
+
+                $sm_cloud['name'] = $file_path;
+                $sm_cloud['bucket'] = $bucket;
+                $sm_cloud['fileLink'] = $filelink;
+
+                if ($dry_run) {
+                    WP_CLI::log('Would fix #' .$id . ' → ' .$filelink);
+                } else {
+                    update_post_meta($id, 'sm_cloud', $sm_cloud);
+                    WP_CLI::log('✅ Fixed attachment #' . $id . ' → ' . $filelink);
+                }
+                $fixed++;
+            }
+            $paged++;
+            wp_reset_postdata();
+        } while ($query->found_posts > ($paged - 1) * $per_page);
+
+        if ($dry_run) {
+            WP_CLI::success('Dry run finished. No changes made. ' .
+                            $fixed . ' attachment(s) would be updated. ' .
+                            $not_needed . ' attachment(s) would not need changes.');
+        } else {
+            WP_CLI::success('Repair complete. ' .
+                            $fixed . ' attachment(s) updated. ' .
+                            $not_needed . ' attachment(s) did not need changes.');
+        }
+    }
+}
+
+WP_CLI::add_command('mediafiles', 'WP_Mediafiles_Repair_Command');


### PR DESCRIPTION
Many images from the interim period where the bucket properties were wrong, got uploaded without proper metadata (`sm_cloud`) information. That results in `wp-stateless` always building their live url dynamically each month. 

This data migration is fixing that by adding at least the very basic metadata needed for those images to have a url that reflects the date they got uploaded.

### Testing

1. Start a development environment: `npm run nro:install aotearoa`
2. Since Aotearoa's backup bucket is slightly different than other sites you'll probably get a really old version. To update to a newer, do this:
```
gcloud storage cp gs://planet4-new-zealand-master-db-backup/v0.266/planet4-new-zealand-master-v0.266-20251007T091906Z.sql.gz planet4-new-zealand-master-v0.266-20251007T091906Z.sql.gz
npm run db:import planet4-new-zealand-master-v0.266-20251007T091906Z.sql.gz planet4_aotearoa
```
3. Login to Admin Panel. Go to _Media Library -> Stateless settings_ and copy all the settings from Aotearoa's dev site same page.
4. Go to the Media Library and choose "May" from the date filter. Images should be broken and their url should be wrong.
5. Go to `planet4/themes/planet4-child-theme-aotearoa` and switch to this branch.
6. Run the command with the `--dry` flag to verify it runs properly:
```
npx wp-env run cli wp mediafiles repair --dry-run
```
7. You should see the verbose output where some images will be fixed while others are already fine.
8. Run the command without `--dry-run`
9. The "May" Media Library files should be fixed now.
10. If you want to make changes in the script in `wp-cli.php` you can re-import the original database from step 2 and repeat step 3.